### PR TITLE
Update 20190502211914_notifications.js (migration file)

### DIFF
--- a/migrations/20190502211914_notifications.js
+++ b/migrations/20190502211914_notifications.js
@@ -1,5 +1,5 @@
-exports.up = function(knex, Promise) {
-  return knex.schema.createTable('notifications', tbl => {
+exports.up = function (knex, Promise) {
+  return knex.schema.createTable('notifications', (tbl) => {
     tbl.increments('id')
     tbl
       .integer('user_id')
@@ -8,11 +8,10 @@ exports.up = function(knex, Promise) {
       .onDelete('cascade')
       .onUpdate('cascade')
       .notNullable()
-
     tbl
-      .integer('post_id')
+      .integer('newsfeed_id')
       .references('id')
-      .inTable('posts')
+      .inTable('newsfeed_posts')
       .onDelete('cascade')
       .onUpdate('cascade')
       .notNullable()
@@ -25,6 +24,6 @@ exports.up = function(knex, Promise) {
   })
 }
 
-exports.down = function(knex, Promise) {
+exports.down = function (knex, Promise) {
   return knex.schema.dropTableIfExists('notifications')
 }


### PR DESCRIPTION
The foreign id in the notifications table should reference table "newsfeed" instead of incorrectly referencing "posts" table
# Description

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Cleanup (no change in functionality is expected)

## Change status

- [X] Complete, tested, ready to review and merge
- [ ] Work-in-Progress, PR is for discussion/feedback

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
- [ ] I have made corresponding changes to the documentation
